### PR TITLE
When running under iOS 8 beta (using XCode 6 beta), after dismissing the...

### DIFF
--- a/VIPER TODO/Classes/Modules/Add/User Interface/Transition/VTDAddPresentationTransition.m
+++ b/VIPER TODO/Classes/Modules/Add/User Interface/Transition/VTDAddPresentationTransition.m
@@ -56,7 +56,6 @@
     toVC.transitioningBackgroundView = blurView;
     
 	UIView *containerView = [transitionContext containerView];
-    [containerView addSubview:fromVC.view];
     [containerView addSubview:blurView];
 	[containerView addSubview:toVC.view];
     


### PR DESCRIPTION
... Add View Controller the screen goes black and no further interaction is possible.

What appears to be happening is that views become the child of a UITransitionView. When the Add views are dismissed it takes all other views with it.  With this line remove the UITransitionView only owns the new Add related views, and therefore behaves as expected.  The change does not appear to cause any problems in iOS 7.  The Swift version of the code does not have this line.
